### PR TITLE
BUGFIX: Add page cache tag manually

### DIFF
--- a/Classes/Hooks/ContentPostProcHook.php
+++ b/Classes/Hooks/ContentPostProcHook.php
@@ -32,6 +32,7 @@ class ContentPostProcHook
     protected function getPageCacheTags(TypoScriptFrontendController $tsfe)
     {
         $pageCacheTags = $tsfe->getPageCacheTags();
+        $pageCacheTags[] = 'pageId_' . $tsfe->id;
 
         $pageCacheTags = array_unique($pageCacheTags);
         $pageCacheTags = $this->simplifyCacheTags($pageCacheTags);


### PR DESCRIPTION
Since we move the varnish cache tag header to ContentPostProcHook
the pageId_${id} tag is not present anymore. We need to add it
manuelly as this specific cache tag is added short bevor writing the
cache entry ($tsfe->setPageCacheContent) is written.